### PR TITLE
Changes to Section 3 after Francesca's review

### DIFF
--- a/draft-ietf-core-echo-request-tag.md
+++ b/draft-ietf-core-echo-request-tag.md
@@ -330,7 +330,7 @@ For those cases, Request-Tag is the proxy-safe elective option suggested in {{RF
 When initializing a new block-wise operation, a client has to look at other active operations:
 
 * If any of them is matchable to the new one, and the client neither wants to cancel the old one nor postpone the new one,
-it can pick a Request-Tag value that is not in use by the other matchable operations for the new operation.
+it can pick a Request-Tag value (including the absent option) that is not in use by the other matchable operations for the new operation.
 
 * Otherwise, it can start the new operation without setting the Request-Tag option on it.
 

--- a/draft-ietf-core-echo-request-tag.md
+++ b/draft-ietf-core-echo-request-tag.md
@@ -276,8 +276,8 @@ starting a request operation matchable to a previous operation where neither has
 therefore constitutes request tag recycling just as well
 (also called "recycling the absent option").
 
-Clients MUST NOT recycle a request tag unless the first operation has concluded.
-What constitutes a concluded operation depends on the application, and is outlined individually in {{req-tag-applications}}.
+Clients that use Request-Tag for a particular purpose (like in {{req-tag-applications}}) MUST NOT recycle a request tag unless the first operation has concluded.
+What constitutes a concluded operation depends on that purpose, and is defined there.
 
 When Block1 and Block2 are combined in an operation,
 the Request-Tag of the Block1 phase is set in the Block2 phase as well

--- a/draft-ietf-core-echo-request-tag.md
+++ b/draft-ietf-core-echo-request-tag.md
@@ -269,6 +269,9 @@ or it can forget about the state established with the older operation and respon
 ## Setting the Request-Tag
 
 For each separate block-wise request operation, the client can choose a Request-Tag value, or choose not to set a Request-Tag.
+It needs to be set to the same value (or unset) in all messages belonging to the same operation,
+as otherwise they are treated as separate operations by the server.
+
 Starting a request operation matchable to a
 previous operation and even using the same Request-Tag value is called request tag recycling.
 The absence of a Request-Tag option is viewed as a value distinct from all values with a single Request-Tag option set;

--- a/draft-ietf-core-echo-request-tag.md
+++ b/draft-ietf-core-echo-request-tag.md
@@ -258,8 +258,8 @@ see {{RFC7252}} Section 5.4.2).
 A server receiving a Request-Tag MUST treat it as opaque and make no assumptions about its content or structure.
 
 Two messages carrying the same Request-Tag is a necessary but not sufficient condition for being part of the same operation.
-They can still be treated as independent messages by the server (e.g. when it sends 2.01/2.04 responses for every block),
-or initiate a new operation (overwriting kept context) when the later message carries Block1 number 0.
+For one, a server may still treat them as independent messages when it sends 2.01/2.04 responses for every block.
+Also, a client that lost interest in an old operation but wants to start over can overwrite the server's old state with a new initial (num=0) Block1 request and the same Request-Tag under some circumstances. Likewise, that results in the new message not being part of he old operation.
 
 As it has always been,
 a server that can only serve a limited number of block-wise operations at the same time

--- a/draft-ietf-core-echo-request-tag.md
+++ b/draft-ietf-core-echo-request-tag.md
@@ -98,7 +98,7 @@ Two request messages are said to be "matchable" if they occur between the same e
 <!-- We could also keep the Request-Tag inside the matchable criterion, but then we'd be saying "matchable except for the Request-Tag" all over the document. -->
 Two operations are said to be matchable if any of their messages are.
 
-Two matchable block-wise operations are said to be "concurrent" if a block of the second request is exchanged even though the client still intends to exchange further blocks in the first operation. (Concurrent block-wise request operations are impossible with the options of {{RFC7959}} because the second operation's block overwrites any state of the first exchange.).
+Two matchable block-wise operations are said to be "concurrent" if a block of the second request is exchanged even though the client still intends to exchange further blocks in the first operation. (Concurrent block-wise request operations from a single endpoint are impossible with the options of {{RFC7959}} (see the last paragraphs of Sections 2.4 and 2.5) because the second operation's block overwrites any state of the first exchange.).
 
 The Echo and Request-Tag options are defined in this document.
 


### PR DESCRIPTION
Also includes changes to a paragraph that will be Section 3 after the pending intro-shoving.

Rationale as in the review response mail:

> "   (Concurrent block-wise request operations are impossible with the
>    options of [RFC7959] because the second operation's block overwrites
>    any state of the first exchange.).
> "
> 
> I believe this is true, but could you point to the section that states
> that? I didn't manage to find it while checking.

Reference made more precise, "from a single endpopoint" added.

> " They can
>    still be treated as independent messages by the server (e.g. when it
>    sends 2.01/2.04 responses for every block), or initiate a new
>    operation (overwriting kept context) when the later message carries
>    Block1 number 0.
> "
>
> I have a hard time parsing/understanding this paragraph, particularly from "or initiate..."

Split up into separate sentences for better clarity.

> * Section 3.3
> 
> "
>    Clients MUST NOT recycle a request tag unless the first operation has
>    concluded. 
> "
> 
> in the case where a client supports but does not use Request-Tag, this implies "concurrent block operations without Request-Tag are not allowed". If that is the case, I would like that to be stated explicitely.
> 
> (also minor, I'd like to add "that support Request-Tag" after "Clients")

That requirement was already kind of conditional on the client using
Request-Tag for a particular purpose -- for otherwise the "unless
concluded" clause makes no sense, for that's defined by the purpose.

Rephrased to pull in the purpose before the MUST and make that explicit.

The "that support Request-Tag" comment should be obsolete by hat, for
only who supports it can use it for something.

(We did, in the chat earlier, consider asking the WG whether that'd all
mean that we're updating RFC7959, but as we're now back to "If you want
to achieve X, do Y" wording, I don't see necessity for such an update).

> * Section 3.3
> 
> The last sentence gives some requirements about where the Request-Tag option can/musty be used per message. I felt the document was missing on usage requirements (e.g. if it is set, it MUST be set for all requests for a specific operation)

Added to the initial (now split up) paragraph of that section.

> * Section 3.4.2
> 
> "
>    When initializing a new block-wise operation, a client has to look at
>    other active operations:
> 
>    o  If any of them is matchable to the new one, and the client neither
>       wants to cancel the old one nor postpone the new one, it can pick
>       a Request-Tag value that is not in use by the other matchable
>       operations for the new operation.
> 
>    o  Otherwise, it can start the new operation without setting the
>       Request-Tag option on it.
> "
> 
> Does not cover the fact that Request-Tag can be omitted if that is a
> different from the other matchable operations. ("pick a new value"
> excludes it)

Explicitly included as an option now.

(Would have been even easier if there were a once-and-for-all definition
of a "request-tag value" that can be absent or have the option's data,
but that had long-winded wording in the last version that was in, and
still might be mistaken by readers that don't have the precise
definition at hand).